### PR TITLE
Add ready dataset on first placement

### DIFF
--- a/addon/components/sidenotes-wrapper.js
+++ b/addon/components/sidenotes-wrapper.js
@@ -44,6 +44,7 @@ export default class SidenotesWrapperComponent extends Component {
 
     idealPlacement.forEach(({ top, note: { element } }) => {
       element.style.top = `${top}px`;
+      element.dataset.ready = true;
     });
 
     this.args.onSidenotesMoved?.();


### PR DESCRIPTION
We add a dataset `ready` to be aware of first placement of each sidenote. This could be used primarly to add transition or display styles.

*This is using `dataset` and not `class` as `class` is re evaluated when focusing a sidenote and the added class would be reseted.*