### PR TITLE
Fix offsetY update when key passed to wrapper

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- Fix reacting to offsetY changes while using @key argument on the wrapper
+
 ## [1.2.0] - 2021-12-07
 
 ### Fixed

--- a/addon/components/sidenote.hbs
+++ b/addon/components/sidenote.hbs
@@ -1,7 +1,8 @@
 <div
   class="sidenote {{if this.isActive "sidenote--active"}}"
   ...attributes
-  {{did-insert this.onDidInsert}}
+  {{did-insert this.onDidInsert @id @offsetY @data}}
+  {{did-update this.onDidInsert @id @offsetY @data}}
   {{observe-resize (fn @onResize @id)}}
 >{{yield
     (hash

--- a/addon/components/sidenote.js
+++ b/addon/components/sidenote.js
@@ -10,10 +10,9 @@ export default class SidenoteComponent extends Component {
   }
 
   @action
-  onDidInsert(element) {
+  onDidInsert(element, [id, offsetY, data]) {
     this.element = element;
 
-    const { id, offsetY, data } = this.args;
     this.args.onRegister({ element, id, offsetY, data });
   }
 }

--- a/tests/integration/components/sidenotes-wrapper-test.js
+++ b/tests/integration/components/sidenotes-wrapper-test.js
@@ -360,4 +360,100 @@ module('Integration | Component | sidenotes-wrapper', function (hooks) {
     assert.ok(sidenotes[0].offsetTop < sidenotes[1].offsetTop);
     assert.ok(sidenotes[1].offsetTop < sidenotes[2].offsetTop);
   });
+
+  test('it triggers placement with key and updating offset', async function (assert) {
+    this.set('items', [{ id: 1, y: 300 }]);
+
+    await render(hbs`
+      <SidenotesWrapper
+        @items={{this.items}}
+        @key='id'
+        @onSidenotesMoved={{this.onSidenotesMoved}}
+        as |Sidenote item|
+      >
+        <Sidenote
+          data-sidenote-id={{item.id}}
+          @id={{item.id}}
+          @offsetY={{item.y}}
+        >
+          Dummy text
+        </Sidenote>
+      </SidenotesWrapper>
+    `);
+
+    assert.dom('[data-sidenote-id="1"]').hasStyle({
+      top: `${this.items[0].y}px`,
+    });
+
+    this.set('items', [{ id: 1, y: 400 }]);
+
+    await settled();
+
+    assert.dom('[data-sidenote-id="1"]').hasStyle({
+      top: `${this.items[0].y}px`,
+    });
+  });
+
+  test('it triggers placement with key and updating offset with custom property', async function (assert) {
+    this.set('items', [{ id: 1, offset_y: 300 }]);
+
+    await render(hbs`
+      <SidenotesWrapper
+        @items={{this.items}}
+        @key='id'
+        @onSidenotesMoved={{this.onSidenotesMoved}}
+        as |Sidenote item|
+      >
+        <Sidenote
+          data-sidenote-id={{item.id}}
+          @id={{item.id}}
+          @offsetY={{item.offset_y}}
+        >
+          Dummy text
+        </Sidenote>
+      </SidenotesWrapper>
+    `);
+
+    assert.dom('[data-sidenote-id="1"]').hasStyle({
+      top: `${this.items[0].offset_y}px`,
+    });
+
+    this.set('items', [{ id: 1, offset_y: 400 }]);
+
+    await settled();
+
+    assert.dom('[data-sidenote-id="1"]').hasStyle({
+      top: `${this.items[0].offset_y}px`,
+    });
+  });
+
+  test('it updates model with key and updating data', async function (assert) {
+    this.set('items', [{ id: 1, y: 300, data: 'foo' }]);
+
+    await render(hbs`
+      <SidenotesWrapper
+        @items={{this.items}}
+        @key='id'
+        @onSidenotesMoved={{this.onSidenotesMoved}}
+        as |Sidenote item|
+      >
+        <Sidenote
+          data-sidenote-id={{item.id}}
+          @id={{item.id}}
+          @offsetY={{item.y}}
+          @data={{item.data}}
+        >
+          {{item.data}}
+        </Sidenote>
+      </SidenotesWrapper>
+    `);
+
+    assert.dom('[data-sidenote-id="1"]').hasText(this.items[0].data);
+
+    this.set('items', [{ id: 1, y: 300, data: 'bar' }]);
+
+    await settled();
+
+    assert.dom('[data-sidenote-id="1"]').hasText(this.items[0].data);
+  });
 });


### PR DESCRIPTION
When we update `offsetY` property passed to sidenote, and we specified a `key` at the same time, then internal models (`notes`) won't be updated on `offsetY` change, as it is watching only the key.

https://contractlive.atlassian.net/browse/CPM-14870