### PR TITLE
fix(deps): override tmp to ^0.2.6 (GHSA-ph9p-34f9-6g65)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6922,18 +6922,6 @@
         "can-symlink": "can-symlink.js"
       }
     },
-    "node_modules/can-symlink/node_modules/tmp": {
-      "version": "0.0.28",
-      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.28.tgz",
-      "integrity": "sha512-c2mmfiBmND6SOVxzogm1oda0OJ1HZVIk/5n26N59dDTh80MUeavpiCls4PGAdkX1PFkKokLpcf7prSjCeXLsJg==",
-      "license": "MIT",
-      "dependencies": {
-        "os-tmpdir": "~1.0.1"
-      },
-      "engines": {
-        "node": ">=0.4.0"
-      }
-    },
     "node_modules/caniuse-lite": {
       "version": "1.0.30001792",
       "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001792.tgz",
@@ -17578,6 +17566,7 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
       "integrity": "sha512-D2FR03Vir7FIu45XBY20mTb+/ZSWB00sjU9jdQXt83gDrI4Ztz5Fs7/yy74g2N5SVQY4xY1qDr4rNddwYRVX0g==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -22065,15 +22054,12 @@
       }
     },
     "node_modules/tmp": {
-      "version": "0.0.33",
-      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.33.tgz",
-      "integrity": "sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==",
+      "version": "0.2.7",
+      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.7.tgz",
+      "integrity": "sha512-e0votIpp4Uo2AJYSzVHV6xCcawuiez3DzqDAbrTc3YxBkplN6e+dM13ZeIcZnDg/QpSuU2zfZ3rzwY8ukEnaXw==",
       "license": "MIT",
-      "dependencies": {
-        "os-tmpdir": "~1.0.2"
-      },
       "engines": {
-        "node": ">=0.6.0"
+        "node": ">=14.14"
       }
     },
     "node_modules/tmpl": {
@@ -22695,19 +22681,6 @@
       },
       "engines": {
         "node": ">= 8"
-      }
-    },
-    "node_modules/watch-detector/node_modules/tmp": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.1.0.tgz",
-      "integrity": "sha512-J7Z2K08jbGcdA1kkQpJSqLF6T0tdQqpR2pnSUXsIchbPdTI9v3e85cLW0d6WDhwuAleOV71j2xWs8qMPfK7nKw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "rimraf": "^2.6.3"
-      },
-      "engines": {
-        "node": ">=6"
       }
     },
     "node_modules/watchpack": {

--- a/package.json
+++ b/package.json
@@ -96,6 +96,7 @@
     "ansi-html": "^0.0.9",
     "braces": "^3.0.3",
     "markdown-it": "^12.3.2",
-    "micromatch": "^4.0.8"
+    "micromatch": "^4.0.8",
+    "tmp": "^0.2.6"
   }
 }


### PR DESCRIPTION
## Contexte

Résout l'alerte Dependabot [#12](https://github.com/concordnow/ember-sidenotes/security/dependabot/12) — **GHSA-ph9p-34f9-6g65 / CVE-2026-44705** : path traversal (CWE-22) dans le paquet transitif `tmp` via les options `prefix`/`postfix`/`dir` non assainies. Sévérité **High**, corrigé en `tmp@0.2.6`.

## Surface

Trois copies de `tmp` étaient installées, toutes `< 0.2.6`, exclusivement tirées par l'outillage de build Ember (ember-cli, broccoli, fixturify-project, watch-detector, external-editor) :

| Copie | Chaîne |
|---|---|
| `tmp@0.0.33` | ember-cli-babel → fixturify-project ; ember-cli → broccoli ; @ember/optional-features → external-editor |
| `tmp@0.0.28` | @glimmer/component → broccoli-merge-trees → … → can-symlink |
| `tmp@0.1.0` | ember-cli → watch-detector |

Aucun chemin où une donnée utilisateur non maîtrisée alimente `prefix`/`postfix`/`dir` → risque d'exploitation runtime très faible ; il s'agit de fermer l'alerte de conformité.

## Changement

Ajout d'un override npm `"tmp": "^0.2.6"`. Les trois copies fusionnent désormais en une seule **`tmp@0.2.7`**.

## Vérifications

- `npm ls tmp` → une seule version `0.2.7`, plus aucune `< 0.2.6`
- API consommée (`tmpNameSync`, `setGracefulCleanup`, `dirSync({unsafeCleanup, dir})`, `.name`, `.removeCallback`) toujours présente en 0.2.x
- `npm run build` ✅ (couvre la nouvelle validation de l'option `dir` du correctif)
- `npm run test:ember` ✅ 23/23

🤖 Generated with [Claude Code](https://claude.com/claude-code)