### PR TITLE
build(deps): fix moderate audit vulns in testem toolchain

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11781,9 +11781,9 @@
       }
     },
     "node_modules/engine.io": {
-      "version": "6.6.7",
-      "resolved": "https://registry.npmjs.org/engine.io/-/engine.io-6.6.7.tgz",
-      "integrity": "sha512-DgOngfDKM2EviOH3Mr9m7ks1q8roetLy/IMmYthAYzbpInMbYc/GS+fWFA3rl1gvwKVsQrVV61fo5emD1y3OJQ==",
+      "version": "6.6.8",
+      "resolved": "https://registry.npmjs.org/engine.io/-/engine.io-6.6.8.tgz",
+      "integrity": "sha512-2agL3ueZhqxoVrfmntO8yuVj+uNSlIOnhykYHk3Cq0ShYPdUjjUiSJrQvXjq01I9jAuI0Zl2YO8Evv5Mqytm5g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -11796,7 +11796,7 @@
         "cors": "~2.8.5",
         "debug": "~4.4.1",
         "engine.io-parser": "~5.2.1",
-        "ws": "~8.18.3"
+        "ws": "~8.20.1"
       },
       "engines": {
         "node": ">=10.2.0"
@@ -16853,34 +16853,6 @@
       "dev": true,
       "license": "ISC"
     },
-    "node_modules/node-notifier": {
-      "version": "10.0.1",
-      "resolved": "https://registry.npmjs.org/node-notifier/-/node-notifier-10.0.1.tgz",
-      "integrity": "sha512-YX7TSyDukOZ0g+gmzjB6abKu+hTGvO8+8+gIFDsRCU2t8fLV/P2unmt+LGFaIa4y64aX98Qksa97rgz4vMNeLQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "growly": "^1.3.0",
-        "is-wsl": "^2.2.0",
-        "semver": "^7.3.5",
-        "shellwords": "^0.1.1",
-        "uuid": "^8.3.2",
-        "which": "^2.0.2"
-      }
-    },
-    "node_modules/node-notifier/node_modules/semver": {
-      "version": "7.8.0",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.0.tgz",
-      "integrity": "sha512-AcM7dV/5ul4EekoQ29Agm5vri8JNqRyj39o0qpX6vDF2GZrtutZl5RwgD1XnZjiTAfncsJhMI48QQH3sN87YNA==",
-      "dev": true,
-      "license": "ISC",
-      "bin": {
-        "semver": "bin/semver.js"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
     "node_modules/node-releases": {
       "version": "2.0.44",
       "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.44.tgz",
@@ -20341,14 +20313,14 @@
       }
     },
     "node_modules/socket.io-adapter": {
-      "version": "2.5.6",
-      "resolved": "https://registry.npmjs.org/socket.io-adapter/-/socket.io-adapter-2.5.6.tgz",
-      "integrity": "sha512-DkkO/dz7MGln0dHn5bmN3pPy+JmywNICWrJqVWiVOyvXjWQFIv9c2h24JrQLLFJ2aQVQf/Cvl1vblnd4r2apLQ==",
+      "version": "2.5.7",
+      "resolved": "https://registry.npmjs.org/socket.io-adapter/-/socket.io-adapter-2.5.7.tgz",
+      "integrity": "sha512-e0LyK91f3cUxTmv95/KzoLg47+zF+s/sbxRGDNsyG4dmIP8ZSX8ax6byOxfJXeNNtS/8AZlfD+uP7gBeR7DLlg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "debug": "~4.4.1",
-        "ws": "~8.18.3"
+        "ws": "~8.20.1"
       }
     },
     "node_modules/socket.io-parser": {
@@ -21318,9 +21290,9 @@
       "license": "MIT"
     },
     "node_modules/testem": {
-      "version": "3.20.0",
-      "resolved": "https://registry.npmjs.org/testem/-/testem-3.20.0.tgz",
-      "integrity": "sha512-SSFfJQK/SGruISFjoKG2jCYwK596wWNPJFj2Wo77GzeIUxZ8ZjuwpyF01uekTLu4ITL6i9R4m1sWaKPK/HsunA==",
+      "version": "3.20.1",
+      "resolved": "https://registry.npmjs.org/testem/-/testem-3.20.1.tgz",
+      "integrity": "sha512-HMbcVlrRDt+GjEGJZrPSCp0XFzM7SSdmLvNSJm++hIITEIMoccCQGikvelOO/NjfZJ0HTZCEyvg3+CIStjaZqQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -21340,14 +21312,14 @@
         "minimatch": "^10.2.5",
         "mkdirp": "^3.0.1",
         "mustache": "^4.2.0",
-        "node-notifier": "^10.0.1",
         "printf": "^0.6.1",
         "proc-log": "^6.1.0",
         "rimraf": "^6.1.3",
         "socket.io": "^4.8.3",
         "spawn-args": "^0.2.0",
         "styled_string": "0.0.1",
-        "tap-parser": "^18.3.0"
+        "tap-parser": "^18.3.0",
+        "toasted-notifier": "^10.1.0"
       },
       "bin": {
         "testem": "testem.js"
@@ -22090,6 +22062,39 @@
       },
       "engines": {
         "node": ">=8.0"
+      }
+    },
+    "node_modules/toasted-notifier": {
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/toasted-notifier/-/toasted-notifier-10.1.0.tgz",
+      "integrity": "sha512-SvAufC4t75lRqwQtComPeDC93j8Toy3BRsD1cMIZ+YdfxTnIyxQb+YCuhXohNFDGJPI+RgOYImkDX76fTo1YDA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://buymeacoffee.com/aetherinox"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "growly": "^1.3.0",
+        "is-wsl": "^2.2.0",
+        "semver": "^7.7.2",
+        "shellwords": "^0.1.1",
+        "which": "^2.0.2"
+      }
+    },
+    "node_modules/toasted-notifier/node_modules/semver": {
+      "version": "7.8.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.1.tgz",
+      "integrity": "sha512-rkVq3IXh+4FDGch+KwzX3aV9W3kO54GyEgpvBzSyctDA6Xtd7RJQV1xmXbeQp5v7+VzLOfVqiutSE6GICgPFvg==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/toidentifier": {
@@ -23145,9 +23150,9 @@
       }
     },
     "node_modules/ws": {
-      "version": "8.18.3",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.3.tgz",
-      "integrity": "sha512-PEIGCY5tSlUt50cqyMXfCzX+oOPqN0vuGqWzbcJ2xvnkzkq46oOpz7dQaTDBdfICb4N14+GARUDw2XV2N4tvzg==",
+      "version": "8.20.1",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.20.1.tgz",
+      "integrity": "sha512-It4dO0K5v//JtTXuPkfEOaI3uUN87iYPnqo/ZzqCoG3g8uhA66QUMs/SrM0YK7/NAu+r4LMh/9dq2A7k+rHs+w==",
       "dev": true,
       "license": "MIT",
       "engines": {


### PR DESCRIPTION
## Contexte

Correction des vulnérabilités `npm audit` corrigeables **sans toucher à la version d'Ember** (le repo reste sur `ember-source ~3.28`).

Complète la PR `tmp` déjà mergée (`35578c7`) : celle-ci avait éliminé la vuln *high* + une cascade de *low*. Cette PR s'attaque aux 5 *moderate* restantes de la chaîne du test-runner `testem`.

## Changements

`package-lock.json` uniquement — toutes les deps touchées sont **transitives et dev-only** (test-runner, jamais embarqué dans l'addon publié) :

| Paquet | Avant → Après | Advisory |
|--------|---------------|----------|
| `ws` | 8.18.3 → 8.20.1 | [GHSA-58qx-3vcg-4xpx](https://github.com/advisories/GHSA-58qx-3vcg-4xpx) |
| `engine.io` | 6.6.7 → 6.6.8 | via `ws` |
| `socket.io-adapter` | 2.5.6 → 2.5.7 | via `ws` |
| `testem` | 3.20.0 → 3.20.1 | remplace `node-notifier` par `toasted-notifier` |
| `node-notifier` | retiré | [GHSA-w5hq-g745-h8pq](https://github.com/advisories/GHSA-w5hq-g745-h8pq) (`uuid`) |

## Vérification

- ✅ Suite de tests : **23/23** (`ember test`) — `testem` étant le paquet modifié, son bon fonctionnement est directement prouvé.
- ✅ Arbre de dépendances cohérent (`npm ls`).
- ✅ Aucun changement runtime / `package.json` inchangé.

## Vulnérabilités restantes (non corrigées, par choix)

Les 10 restantes sont toutes verrouillées par le pinning de la toolchain Ember (`ember-cli@3.28`, `ember-try`) et n'ont pas de patch drop-in sûr :
- chaîne `got` (sous `package-json@6`) et `clean-css@3` (sous `broccoli-clean-css@1`) → l'override casserait le consommateur ;
- `uuid` → chemin vulnérable non atteignable (ember-cli n'utilise que `uuid.v4()` sans buffer) ;
- le reste exige `ember-cli@7` → bump majeur d'Ember, exclu.

🤖 Generated with [Claude Code](https://claude.com/claude-code)