### PR TITLE
build(deps): bump markdown-it override to ^14.2.0 (CVE-2026-48988)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15838,13 +15838,23 @@
       "license": "MIT"
     },
     "node_modules/linkify-it": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/linkify-it/-/linkify-it-3.0.3.tgz",
-      "integrity": "sha512-ynTsyrFSdE5oZ/O9GEf00kPngmOfVwazR5GKDq6EYfhlpFug3J2zybX56a2PRRpc9P+FuSoGNAwjlbDs9jJBPQ==",
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/linkify-it/-/linkify-it-5.0.1.tgz",
+      "integrity": "sha512-wVoTjP4Q6R0NW5hiZkVJaFZPWgtXfoGF+6LucL3/FtiNjmcHhYjEr5f1Kqjirc1nBW07J/ZuRFumqr2oqccEWg==",
       "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/markdown-it"
+        }
+      ],
       "license": "MIT",
       "dependencies": {
-        "uc.micro": "^1.0.1"
+        "uc.micro": "^2.0.0"
       }
     },
     "node_modules/livereload-js": {
@@ -16309,20 +16319,31 @@
       }
     },
     "node_modules/markdown-it": {
-      "version": "12.3.2",
-      "resolved": "https://registry.npmjs.org/markdown-it/-/markdown-it-12.3.2.tgz",
-      "integrity": "sha512-TchMembfxfNVpHkbtriWltGWc+m3xszaRD0CZup7GFFhzIgQqxIfn3eGj1yZpfuflzPvfkt611B2Q/Bsk1YnGg==",
+      "version": "14.2.0",
+      "resolved": "https://registry.npmjs.org/markdown-it/-/markdown-it-14.2.0.tgz",
+      "integrity": "sha512-1TGiQiJVRQ3NPmZH6sx5Cfnmg6GQm9jvC1ch4TK511NjSJvjzKLzn5pPfZRNZkRPZP0HqCioSndqH8v2nRaWVQ==",
       "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/markdown-it"
+        }
+      ],
       "license": "MIT",
       "dependencies": {
         "argparse": "^2.0.1",
-        "entities": "~2.1.0",
-        "linkify-it": "^3.0.1",
-        "mdurl": "^1.0.1",
-        "uc.micro": "^1.0.5"
+        "entities": "^4.4.0",
+        "linkify-it": "^5.0.1",
+        "mdurl": "^2.0.0",
+        "punycode.js": "^2.3.1",
+        "uc.micro": "^2.1.0"
       },
       "bin": {
-        "markdown-it": "bin/markdown-it.js"
+        "markdown-it": "bin/markdown-it.mjs"
       }
     },
     "node_modules/markdown-it-terminal": {
@@ -16370,11 +16391,14 @@
       "license": "MIT"
     },
     "node_modules/markdown-it/node_modules/entities": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/entities/-/entities-2.1.0.tgz",
-      "integrity": "sha512-hCx1oky9PFrJ611mf0ifBLBRW8lUUVRlFolb5gWRfIELabBlbp9xZvrqZLZAs+NxFnbfQoeGd8wDkygjg7U85w==",
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
+      "integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==",
       "dev": true,
       "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
       "funding": {
         "url": "https://github.com/fb55/entities?sponsor=1"
       }
@@ -16420,9 +16444,9 @@
       "license": "CC0-1.0"
     },
     "node_modules/mdurl": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/mdurl/-/mdurl-1.0.1.tgz",
-      "integrity": "sha512-/sKlQJCBYVY9Ers9hqzKou4H6V5UWc/M59TH2dvkt+84itfnq7uFOMLpOiOS4ujvHP4etln18fmIxA5R5fll0g==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/mdurl/-/mdurl-2.0.0.tgz",
+      "integrity": "sha512-Lf+9+2r+Tdp5wXDXC4PcIBjTDtq4UKjCPMQhKIuzpJNW0b96kVqSwW0bT7FhRSfmAiFYgP+SCRvdrDozfh0U5w==",
       "dev": true,
       "license": "MIT"
     },
@@ -18657,6 +18681,16 @@
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
       "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/punycode.js": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/punycode.js/-/punycode.js-2.3.1.tgz",
+      "integrity": "sha512-uxFIHU0YlHYhDQtV4R9J6a52SLx28BCjT+4ieh7IGbgwVJWO+km431c4yRlREUAsAmt/uMjQUyQHNEPf0M39CA==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6"
@@ -22399,9 +22433,9 @@
       "license": "MIT"
     },
     "node_modules/uc.micro": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/uc.micro/-/uc.micro-1.0.6.tgz",
-      "integrity": "sha512-8Y75pvTYkLJW2hWQHXxoqRgV7qb9B+9vFEtidML+7koHUFapnVJAZ6cKs+Qjz5Aw3aZWHMC6u0wJE3At+nSGwA==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/uc.micro/-/uc.micro-2.1.0.tgz",
+      "integrity": "sha512-ARDJmphmdvUk6Glw7y9DQ2bFkKBHwQHLi2lsaH6PPmz/Ka9sFOBsBluozhDltWmnv9u/cF6Rt87znRTPV+yp/A==",
       "dev": true,
       "license": "MIT"
     },

--- a/package.json
+++ b/package.json
@@ -96,7 +96,7 @@
     "@babel/runtime": "^7.26.10",
     "ansi-html": "^0.0.9",
     "braces": "^3.0.3",
-    "markdown-it": "^12.3.2",
+    "markdown-it": "^14.2.0",
     "micromatch": "^4.0.8",
     "tmp": "^0.2.6"
   }


### PR DESCRIPTION
## Contexte

Dependabot [alerte #14](https://github.com/concordnow/ember-sidenotes/security/dependabot/14) — **CVE-2026-48988 / GHSA-6v5v-wf23-fmfq** (severity *medium*, CVSS 3.1 = 5.3).

`markdown-it` présente une complexité quadratique **O(n²)** dans la règle *smartquotes* (`replaceAt()`). Une entrée markdown faite de guillemets consécutifs consomme un temps CPU excessif → déni de service. Toutes les versions `<= 14.1.1` sont touchées, **corrigé en `14.2.0`**.

## Pourquoi l'override existant ne suffisait pas

`package.json` forçait déjà `markdown-it` via un `override`, mais à `^12.3.2` — qui reste dans la plage vulnérable.

```
ember-sidenotes
└─ ember-cli@3.28.6              (devDependency, scope = development)
   ├─ markdown-it@12.3.2         (override "^12.3.2")  ← vulnérable
   └─ markdown-it-terminal@0.2.1 → markdown-it (deduped)
```

## Correctif

Monter l'override à `^14.2.0` :

```diff
-    "markdown-it": "^12.3.2",
+    "markdown-it": "^14.2.0",
```

L'`override` npm force la version corrigée sur **ember-cli ET markdown-it-terminal**, indépendamment des plages déclarées. **Aucune mise à jour d'ember-cli 3.28 n'est nécessaire** (cohérent avec la décision du chapter de rester sur `ember-source ~3.28`).

## Risque réel : faible

`markdown-it` n'est utilisé que par `ember-cli/lib/utilities/markdown-color.js` (colorisation de la sortie terminal), instancié **sans `typographer`** (défaut `false`) → le chemin vulnérable n'est jamais atteint. C'est de l'outillage build/dev sur des entrées non hostiles. Le but est avant tout d'éteindre l'alerte avec la version corrigée.

## Validation

- `npm audit` : `markdown-it` **disparaît** du rapport ✓
- `npm ls markdown-it` → `14.2.0` forcé sur ember-cli et markdown-it-terminal ✓
- `test:ember` : **23/23** ✓
- Scénarios `ember try` supportés (`ember-lts-3.20`, `ember-lts-3.24`, `ember-default-with-jquery`, `ember-classic`) : **SUCCESS** ✓
- Échecs `ember-release` / `ember-beta` / `ember-canary` : **pré-existants**, dus à l'incompatibilité Ember 6/7 avec un addon ciblant 3.28 — sans rapport avec ce changement (markdown-it n'intervient pas dans `ember test`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
